### PR TITLE
Try to avoid ABI problems with newer numpy versions

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 1
+  number: 2
   skip: True  # [py27]
   script: "{{ PYTHON }} setup.py install --single-version-externally-managed --record record.txt --offline"
 
@@ -27,8 +27,8 @@ requirements:
     - pip
     - setuptools
     - astropy >=2.1
-    - cython >=0.27
-    - numpy >=1.11
+    - cython
+    - numpy
 
   run:
     - python


### PR DESCRIPTION
Remove numpy>=1.11 from recipe, as this would in fact use the newest numpy version.
It's better to have the oldest (pin-compatible) version though, because forward compatibility
is usually ensured, but not backward compatibility.

See also bwinkel/cygrid/#9

@conda-forge-admin, please rerender

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x ] Used a fork of the feedstock to propose changes
* [x ] Bumped the build number (if the version is unchanged)
* [x ] Reset the build number to `0` (if the version changed)
* [x ] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
